### PR TITLE
Disable rocket jumping on death in 1.19 branch also.

### DIFF
--- a/src/main/java/dev/cammiescorner/fireworkfrenzy/mixin/PlayerEntityMixin.java
+++ b/src/main/java/dev/cammiescorner/fireworkfrenzy/mixin/PlayerEntityMixin.java
@@ -29,7 +29,7 @@ public abstract class PlayerEntityMixin extends LivingEntity implements BlastJum
 			if(!world.isClient() && (isOnGround() || isSubmergedInWater()))
 				setTimeOnGround(getTimeOnGround() + 1);
 
-			if(getTimeOnGround() > 2 || hasVehicle() || (FireworkFrenzy.config.elytrasCancelRocketJumping && isFallFlying()))
+			if(getTimeOnGround() > 2 || hasVehicle() || (FireworkFrenzy.config.elytrasCancelRocketJumping && isFallFlying()) || !isAlive())
 				setBlastJumping(false);
 		}
 	}


### PR DESCRIPTION
This was already fixed in the 1.18 branch by #7 but not in 1.19,
thus the 1.19 file on curseforge still has this bug.